### PR TITLE
Fix interaction count isssue and set connection test to off by default

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "adapt-elfh-spoor",
-    "version": "5.0.6",
+    "version": "5.0.7",
     "framework": ">=5",
     "homepage": "https://github.com/TechnologyEnhancedLearning/adapt-elfh-spoor",
     "displayName": "e-LfH Spoor",

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -171,6 +171,10 @@ export default class StatefulSession extends Backbone.Controller {
 
   onQuestionRecordInteraction(questionView) {
     if (!this._shouldRecordInteractions) return;
+    if (!this.scorm.isSupported('cmi.interactions._count')) {
+      console.log("recordInteraction: cmi.interactions are not supported by this LMS");
+      return;
+    }
     // View functions are deprecated: getResponseType, getResponse, isCorrect, getLatency
     const questionModel = questionView.model;
     const responseType = (questionModel.getResponseType ? questionModel.getResponseType() : questionView.getResponseType());

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -171,10 +171,7 @@ export default class StatefulSession extends Backbone.Controller {
 
   onQuestionRecordInteraction(questionView) {
     if (!this._shouldRecordInteractions) return;
-    if (!this.scorm.isSupported('cmi.interactions._count')) {
-      console.log("recordInteraction: cmi.interactions are not supported by this LMS");
-      return;
-    }
+    if (!this.scorm.isSupported('cmi.interactions._count')) return;
     // View functions are deprecated: getResponseType, getResponse, isCorrect, getLatency
     const questionModel = questionView.model;
     const responseType = (questionModel.getResponseType ? questionModel.getResponseType() : questionView.getResponseType());

--- a/properties.schema
+++ b/properties.schema
@@ -266,7 +266,7 @@
                       "properties": {
                         "_isEnabled": {
                           "type": "boolean",
-                          "default": true,
+                          "default": false,
                           "title": "Is Enabled",
                           "inputType": "Checkbox",
                           "validators": [],
@@ -274,7 +274,7 @@
                         },
                         "_testOnSetValue": {
                           "type": "boolean",
-                          "default": true,
+                          "default": false,
                           "title": "Test on set value",
                           "inputType": "Checkbox",
                           "validators": [],


### PR DESCRIPTION
Jira link: https://hee-tis.atlassian.net/jira/software/c/projects/TD/boards/165/timeline?component=11172&selectedIssue=TD-3077


### Fix
There was an issue where an attempt to retrieve the cmi.interactions._count from an LMS that does not support this optional SCORM 1.2 element. 

This update also sets the Connection test to default as disabled as it was causing an issue on ESR where it was having a false positive reporting that there was no connection to the LMS.

### Testing
Tricky to test as needs a LMS that does not support cmi.interactions._count
ESR is one such example so it is possible to get a test session on there for testing - note I have tested this on ESR and this update is now in the latest version of the elfh Spoor on Adapt Builder Production so this PR is essentially the necesary "admin"




