### PR TITLE
Feature/td 3183 fix error handling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "adapt-elfh-spoor",
-    "version": "5.0.8",
+    "version": "5.0.9",
     "framework": ">=5",
     "homepage": "https://github.com/TechnologyEnhancedLearning/adapt-elfh-spoor",
     "displayName": "e-LfH Spoor",

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -603,10 +603,8 @@ class ScormWrapper {
       if (error.data.value === '') error.data.value = '\'\'';
     }
 
-    const config = Adapt.course.get('_elfh_spoor') || {};
     const defaultMessages = ScormError.defaultMessages;
-    const configMessages = config?.['_messages'] || {};
-    const messages = Object.assign({}, defaultMessages, configMessages);
+    const messages = Object.assign({}, defaultMessages);
     const message = Handlebars.compile(messages[error.name])(error.data);
 
     switch (error.name) {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -603,7 +603,7 @@ class ScormWrapper {
       if (error.data.value === '') error.data.value = '\'\'';
     }
 
-    const config = Adapt.course.get('_elfh_spoor');
+    const config = Adapt.course.get('_elfh_spoor') || {};
     const defaultMessages = ScormError.defaultMessages;
     const configMessages = config?.['_messages'] || {};
     const messages = Object.assign({}, defaultMessages, configMessages);

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -604,7 +604,9 @@ class ScormWrapper {
     }
 
     const config = Adapt.course.get('_elfh_spoor');
-    const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
+    const defaultMessages = ScormError.defaultMessages;
+    const configMessages = config?.['_messages'] || {};
+    const messages = Object.assign({}, defaultMessages, configMessages);
     const message = Handlebars.compile(messages[error.name])(error.data);
 
     switch (error.name) {


### PR DESCRIPTION
Fix issue with the error dialogue not appearing when an error occurs running the session on a LMS.


### Fix
The error was a result of the course.json file not containing a reference to "_spoor" therefore causing a script error that may cause the session to hang or behave erratically. The course..json would contain a reference to "_spoor" if a custom error message had been added via the elfh Spoor settings but this is not something we do.

Therefore as we do not use the custome error message functionality the fix is to just use the default error messages and not try to pull in custom error messages thereby preventing the script error.


